### PR TITLE
Add basic router

### DIFF
--- a/lib/videoroom_web/endpoint.ex
+++ b/lib/videoroom_web/endpoint.ex
@@ -20,4 +20,6 @@ defmodule VideoRoomWeb.Endpoint do
     ],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()
+
+  plug VideoRoomWeb.Router
 end

--- a/lib/videoroom_web/router.ex
+++ b/lib/videoroom_web/router.ex
@@ -1,0 +1,24 @@
+defmodule VideoRoomWeb.Router do
+  use Phoenix.Router
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  scope "/", VideoRoomWeb do
+    get "/", PageController, :index
+    get "/*path", PageController, :missing
+  end
+end
+
+defmodule VideoRoomWeb.PageController do
+  use Phoenix.Controller, namespace: VideoRoomWeb
+  import Plug.Conn
+
+  def index(conn, _params) do
+    redirect(conn, to: "/index.html")
+  end
+
+  def missing(conn, _params) do
+    send_resp(conn, 404, "Not Found")
+  end
+end


### PR DESCRIPTION
Allows accessing root path ("http://localhost:4000") that is printed when starting the server.
Returns 404 on other paths